### PR TITLE
Feat: add endpoint for API section "Статистика процентных ставок по депозитам"

### DIFF
--- a/backend/bank_iq/core/parsers/interest_rates_parser.py
+++ b/backend/bank_iq/core/parsers/interest_rates_parser.py
@@ -8,7 +8,7 @@ from requests.exceptions import RequestException
 logger = logging.getLogger(__name__)
 
 
-class InterestRatesCreditParser:
+class InterestRatesParser:
     BASE_URL = 'http://www.cbr.ru/dataservice'
 
     @classmethod

--- a/backend/bank_iq/core/utils/meta.py
+++ b/backend/bank_iq/core/utils/meta.py
@@ -1,0 +1,7 @@
+from abc import ABCMeta
+
+from rest_framework import serializers
+
+
+class CombinedMeta(serializers.SerializerMetaclass, ABCMeta):
+    ...

--- a/backend/bank_iq/reports/serializers.py
+++ b/backend/bank_iq/reports/serializers.py
@@ -1,9 +1,45 @@
 import datetime
+from abc import ABC, abstractmethod
 
 from rest_framework import serializers
 
+from core.utils.meta import CombinedMeta
 
-class InterestRatesCreditSerializer(serializers.Serializer):
+
+class BaseAPISerializer(serializers.Serializer, ABC, metaclass=CombinedMeta):
+    from_year = serializers.IntegerField(
+            required=True,
+            help_text="Год начала периода. Должен быть не больше to_year."
+    )
+    to_year = serializers.IntegerField(
+            required=True,
+            help_text="Год окончания периода. Должен быть не больше текущего года."
+    )
+
+    def validate(self, data):
+        from_year = data.get("from_year")
+        to_year = data.get("to_year")
+        if from_year and to_year:
+            if from_year > to_year:
+                raise serializers.ValidationError({"message": "from_year не может быть больше to_year"})
+            if to_year > datetime.datetime.now().year:
+                raise serializers.ValidationError({"message": "to_year не может быть больше текущего года"})
+        return data
+
+    @abstractmethod
+    def validate_publication_id(self, value: int):
+        pass
+
+    @abstractmethod
+    def validate_dataset_id(self, value: int):
+        pass
+
+    @abstractmethod
+    def validate_measure_id(self, value: int):
+        pass
+
+
+class InterestRatesCreditSerializer(BaseAPISerializer):
     publication_id = serializers.IntegerField(
             required=True,
             help_text="ID публикации. Допустимые значения: 14 (В целом по Российской Федерации), "
@@ -38,14 +74,6 @@ class InterestRatesCreditSerializer(serializers.Serializer):
                       "17 (Недвижимость), 18 (Профессиональная деятельность), 19 (Образование), "
                       "20 (Культура и спорт), 21 (Прочее)."
     )
-    from_year = serializers.IntegerField(
-            required=True,
-            help_text="Год начала периода. Должен быть не больше to_year."
-    )
-    to_year = serializers.IntegerField(
-            required=True,
-            help_text="Год окончания периода. Должен быть не больше текущего года."
-    )
 
     def validate_publication_id(self, value: int):
         if value in (14, 15, 16):
@@ -61,7 +89,7 @@ class InterestRatesCreditSerializer(serializers.Serializer):
         }
         if publication_id not in valid_datasets:
             raise serializers.ValidationError({"message": "publication_id должен быть указан для проверки dataset_id"})
-        if value not in valid_datasets.get(publication_id, ()):
+        if value not in valid_datasets.get(publication_id):
             values = list(valid_datasets.get(publication_id))
             raise serializers.ValidationError(
                     {"message": f"dataset_id должен быть равен числу в массиве {values}"
@@ -77,21 +105,68 @@ class InterestRatesCreditSerializer(serializers.Serializer):
         }
         if publication_id not in valid_measures:
             raise serializers.ValidationError({"message": "publication_id должен быть указан для проверки measure_id"})
-        if value not in valid_measures.get(publication_id, ()):
+        if value not in valid_measures.get(publication_id):
             values = list(valid_measures.get(publication_id))
             raise serializers.ValidationError({"message": f"measure_id должен быть равен числу в массиве {values}"
                                                           f" для publication_id={publication_id}"})
         return value
 
-    def validate(self, data):
-        from_year = data.get("from_year")
-        to_year = data.get("to_year")
-        if from_year and to_year:
-            if from_year > to_year:
-                raise serializers.ValidationError({"message": "from_year не может быть больше to_year"})
-            if to_year > datetime.datetime.now().year:
-                raise serializers.ValidationError({"message": "to_year не может быть больше текущего года"})
-        return data
+
+class InterestRatesDepositSerializer(BaseAPISerializer):
+    publication_id = serializers.IntegerField(
+            required=True,
+            help_text="ID публикации. Допустимые значения: 18 (В целом по Российской Федерации), "
+                      "19 (В территориальном разрезе).")
+    dataset_id = serializers.IntegerField(
+            required=True,
+            help_text="ID набора данных. Зависит от publication_id:\n"
+                      "- Для 18: 37 (Ставки по вкладам (депозитам) физических лиц), "
+                      "38 (Ставки по вкладам (депозитам) нефинансовых организаций).\n"
+                      "- Для 19: 39 (Ставки по вкладам (депозитам) физических лиц в рублях), "
+                      "40 (Ставки по вкладам (депозитам) нефинансовых организаций в рублях).")
+    measure_id = serializers.IntegerField(
+            required=True,
+            help_text="ID разреза. Зависит от publication_id:\n"
+                      "- Для 18: 2 (В рублях), 3 (В долларах США), 4 (В евро).\n"
+                      "- Для 19: 23 (Центральный федеральный округ), 42 (Северо-Западный федеральный округ), "
+                      "55 (Южный федеральный округ), 64 (Северо-Кавказский федеральный округ), "
+                      "72 (Приволжский федеральный округ), 87 (Уральский федеральный округ), "
+                      "95 (Сибирский федеральный округ), 106 (Дальневосточный федеральный округ)."
+    )
+
+    def validate_publication_id(self, value: int):
+        if value in (18, 19):
+            return value
+        raise serializers.ValidationError({"message": "publication_id должен быть равен числу в массиве [18, 19]"})
+
+    def validate_dataset_id(self, value: int):
+        publication_id = self.initial_data.get('publication_id')
+        valid_datasets = {
+            18: (37, 38),
+            19: (39, 40),
+        }
+        if publication_id not in valid_datasets:
+            raise serializers.ValidationError({"message": "publication_id должен быть указан для проверки dataset_id"})
+        if value not in valid_datasets.get(publication_id):
+            values = list(valid_datasets.get(publication_id))
+            raise serializers.ValidationError(
+                    {"message": f"dataset_id должен быть равен числу в массиве {values}"
+                                f" для publication_id={publication_id}"})
+        return value
+
+    def validate_measure_id(self, value: int):
+        publication_id = self.initial_data.get('publication_id')
+        valid_measures = {
+            18: (2, 3, 4),
+            19: (23, 42, 55, 64, 72, 87, 95, 106),
+        }
+        if publication_id not in valid_measures:
+            raise serializers.ValidationError({"message": "publication_id должен быть указан для проверки measure_id"})
+        if value not in valid_measures.get(publication_id):
+            values = list(valid_measures.get(publication_id))
+            raise serializers.ValidationError({"message": f"measure_id должен быть равен числу в массиве {values}"
+                                                          f" для publication_id={publication_id}"})
+        return value
 
 
 class DTRangeSerializer(serializers.Serializer):
@@ -128,7 +203,7 @@ class UnitSerializer(serializers.Serializer):
     val = serializers.CharField(help_text="Название единицы измерения (например, '% годовых').")
 
 
-class InterestRatesCreditResponseSerializer(serializers.Serializer):
+class InterestRatesResponseSerializer(serializers.Serializer):
     DTRange = DTRangeSerializer(many=True, help_text="Диапазон доступных годов для данных.")
     RawData = DataItemSerializer(many=True, help_text="Список данных о процентных ставках.")
     SType = STypeSerializer(many=True, help_text="Информация о публикации и наборе данных.")

--- a/backend/bank_iq/reports/urls.py
+++ b/backend/bank_iq/reports/urls.py
@@ -1,9 +1,11 @@
 from django.urls import path
 
-from .views import InterestRatesCreditAPIView
+from .views import InterestRatesCreditAPIView, InterestRatesDepositAPIView
 
 
 urlpatterns = [
     path("parse/interest_rates_credit", InterestRatesCreditAPIView.as_view(),
          name="InterestRatesCreditAPIView"),
+    path("parse/interest_rates_deposit", InterestRatesDepositAPIView.as_view(),
+         name="InterestRatesDepositAPIView"),
 ]

--- a/backend/bank_iq/reports/views.py
+++ b/backend/bank_iq/reports/views.py
@@ -4,8 +4,8 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from core.parsers.interest_rates_parser import InterestRatesCreditParser
-from .serializers import InterestRatesCreditResponseSerializer, InterestRatesCreditSerializer
+from core.parsers.interest_rates_parser import InterestRatesParser
+from .serializers import InterestRatesCreditSerializer, InterestRatesDepositSerializer, InterestRatesResponseSerializer
 
 
 class InterestRatesCreditAPIView(APIView):
@@ -20,7 +20,7 @@ class InterestRatesCreditAPIView(APIView):
             request=InterestRatesCreditSerializer,
             responses={
                 200: OpenApiResponse(
-                        response=InterestRatesCreditResponseSerializer,
+                        response=InterestRatesResponseSerializer,
                         description="Успешный ответ с данными о процентных ставках",
                         examples=[
                             OpenApiExample(
@@ -269,7 +269,7 @@ class InterestRatesCreditAPIView(APIView):
         serializer.is_valid(raise_exception=True)
         params = serializer.validated_data
 
-        data = InterestRatesCreditParser.parse(
+        data = InterestRatesParser.parse(
                 publication_id=params.get("publication_id"),
                 dataset_id=params.get("dataset_id"),
                 measure_id=params.get("measure_id"),
@@ -279,5 +279,293 @@ class InterestRatesCreditAPIView(APIView):
         if "message" in data:
             return Response(data, status=status.HTTP_422_UNPROCESSABLE_ENTITY)
 
-        response_serializer = InterestRatesCreditResponseSerializer(instance=data)
+        response_serializer = InterestRatesResponseSerializer(instance=data)
+        return Response(response_serializer.data, status=status.HTTP_200_OK)
+
+
+class InterestRatesDepositAPIView(APIView):
+    @extend_schema(
+            summary="Получение данных о процентных ставках по депозитам",
+            description=(
+                    "Эндпоинт для получения данных о процентных ставках по депозитам от ЦБ РФ. "
+                    "Требуется указать ID публикации, набора данных, разреза и диапазон годов. "
+                    "Возвращает структурированные данные, включая значения ставок, описание публикации, "
+                    "категории депозитов, единицы измерения и диапазон доступных годов"
+            ),
+            request=InterestRatesDepositSerializer,
+            responses={
+                200: OpenApiResponse(
+                        description="Успешный ответ с данными о процентных ставках по депозитам",
+                        examples=[
+                            OpenApiExample(
+                                    name="Пример ответа для publication_id=18, dataset_id=37, measure_id=2",
+                                    value={
+                                        "RawData": [{
+                                            "colId": 1,
+                                            "element_id": 1,
+                                            "measure_id": 2,
+                                            "unit_id": 1,
+                                            "obs_val": 1.98,
+                                            "rowId": 265,
+                                            "dt": "Январь 2014",
+                                            "periodicity": "month",
+                                            "date": "2014-02-01T00:00:00",
+                                            "digits": 2},
+                                            {"colId": 1,
+                                             "element_id": 1,
+                                             "measure_id": 2,
+                                             "unit_id": 1,
+                                             "obs_val": 10.81,
+                                             "rowId": 404,
+                                             "dt": "Август 2025",
+                                             "periodicity": "month",
+                                             "date": "2025-09-01T00:00:00",
+                                             "digits": 2}
+                                        ],
+                                        "headerData": [{"id": 1, "elname": "\"До востребования\""},
+                                                       {"id": 2, "elname": "До 30 дней, включая ''до востребования''"},
+                                                       {"id": 3, "elname": "До 30 дней, кроме ''до востребования''"},
+                                                       {"id": 4, "elname": "От 31 до 90 дней"},
+                                                       {"id": 5, "elname": "От 91 до 180 дней"},
+                                                       {"id": 6, "elname": "От 181 дня до 1 года"},
+                                                       {"id": 7, "elname": "До 1 года, включая ''до востребования''"},
+                                                       {"id": 8, "elname": "До 1 года, кроме ''до востребования''"},
+                                                       {"id": 9, "elname": "От 1 года до 3 лет"},
+                                                       {"id": 10, "elname": "Свыше 3 лет"},
+                                                       {"id": 11, "elname": "Свыше 1 года"}],
+                                        "units": [{"id": 1, "val": "% годовых"},
+                                                  {"id": 2, "val": "%"},
+                                                  {"id": 3, "val": "млрд руб."},
+                                                  {"id": 4, "val": "млн долларов США"},
+                                                  {"id": 5, "val": "месяцев"},
+                                                  {"id": 6, "val": "млн руб."},
+                                                  {"id": 7, "val": "единиц"},
+                                                  {"id": 8, "val": "число опрошенных"},
+                                                  {"id": 9, "val": "пунктов"},
+                                                  {"id": 10, "val": "руб."}],
+                                        "DTRange": [{"FromY": 2014, "ToY": 2025}],
+                                        "SType": [{
+                                            "sType": 1,
+                                            "dsName": "Ставки по вкладам (депозитам) физических лиц",
+                                            "PublName": "В целом по Российской Федерации"}]
+                                    }
+                            ),
+                            OpenApiExample(
+                                    name="Пример ответа для publication_id=18, dataset_id=38, measure_id=2",
+                                    value={
+                                        "RawData": [{"colId": 2,
+                                                     "element_id": 2,
+                                                     "measure_id": 2,
+                                                     "unit_id": 1,
+                                                     "obs_val": 5.54,
+                                                     "rowId": 265,
+                                                     "dt": "Январь 2014",
+                                                     "periodicity": "month",
+                                                     "date": "2014-02-01T00:00:00",
+                                                     "digits": 2},
+                                                    {"colId": 2,
+                                                     "element_id": 2,
+                                                     "measure_id": 2,
+                                                     "unit_id": 1,
+                                                     "obs_val": 16.48,
+                                                     "rowId": 404,
+                                                     "dt": "Август 2025",
+                                                     "periodicity": "month",
+                                                     "date": "2025-09-01T00:00:00",
+                                                     "digits": 2}
+                                                    ],
+                                        "headerData": [{"id": 2, "elname": "До 30 дней, включая ''до востребования''"},
+                                                       {"id": 4, "elname": "От 31 до 90 дней"},
+                                                       {"id": 5, "elname": "От 91 до 180 дней"},
+                                                       {"id": 6, "elname": "От 181 дня до 1 года"},
+                                                       {"id": 7, "elname": "До 1 года, включая ''до востребования''"},
+                                                       {"id": 9, "elname": "От 1 года до 3 лет"},
+                                                       {"id": 10, "elname": "Свыше 3 лет"},
+                                                       {"id": 11, "elname": "Свыше 1 года"}],
+                                        "units": [{"id": 1, "val": "% годовых"},
+                                                  {"id": 2, "val": "%"},
+                                                  {"id": 3, "val": "млрд руб."},
+                                                  {"id": 4, "val": "млн долларов США"},
+                                                  {"id": 5, "val": "месяцев"},
+                                                  {"id": 6, "val": "млн руб."},
+                                                  {"id": 7, "val": "единиц"},
+                                                  {"id": 8, "val": "число опрошенных"},
+                                                  {"id": 9, "val": "пунктов"},
+                                                  {"id": 10, "val": "руб."}],
+                                        "DTRange": [{"FromY": 2014, "ToY": 2025}],
+                                        "SType": [{"sType": 1,
+                                                   "dsName": "Ставки по вкладам (депозитам) нефинансовых организаций",
+                                                   "PublName": "В целом по Российской Федерации"}
+                                                  ]
+                                    }
+                            ),
+                            OpenApiExample(
+                                    name="Пример ответа для publication_id=19, dataset_id=39, measure_id=23",
+                                    value={
+                                        "RawData": [
+                                            {"colId": 7,
+                                             "element_id": 7,
+                                             "measure_id": 23,
+                                             "unit_id": 1,
+                                             "obs_val": 6.05,
+                                             "rowId": 325,
+                                             "dt": "Январь 2019",
+                                             "periodicity": "month",
+                                             "date": "2019-02-01T00:00:00",
+                                             "digits": 2
+                                             }, {"colId": 7,
+                                                 "element_id": 7,
+                                                 "measure_id": 23,
+                                                 "unit_id": 1,
+                                                 "obs_val": 15.74,
+                                                 "rowId": 404,
+                                                 "dt": "Август 2025",
+                                                 "periodicity": "month",
+                                                 "date": "2025-09-01T00:00:00",
+                                                 "digits": 2}
+                                        ],
+                                        "headerData": [{"id": 7, "elname": "До 1 года, включая ''до востребования''"},
+                                                       {"id": 11, "elname": "Свыше 1 года"}],
+                                        "units": [{"id": 1, "val": "% годовых"},
+                                                  {"id": 2, "val": "%"},
+                                                  {"id": 3, "val": "млрд руб."},
+                                                  {"id": 4, "val": "млн долларов США"},
+                                                  {"id": 5, "val": "месяцев"},
+                                                  {"id": 6, "val": "млн руб."},
+                                                  {"id": 7, "val": "единиц"},
+                                                  {"id": 8, "val": "число опрошенных"},
+                                                  {"id": 9, "val": "пунктов"},
+                                                  {"id": 10, "val": "руб."}],
+                                        "DTRange": [{"FromY": 2019, "ToY": 2025}],
+                                        "SType": [{"sType": 1,
+                                                   "dsName": "Ставки по вкладам (депозитам) физических лиц в рублях",
+                                                   "PublName": "В территориальном разрезе"}]
+                                    }
+                            ),
+                            OpenApiExample(
+                                    name="Пример ответа для publication_id=19, dataset_id=40, measure_id=23",
+                                    value={
+                                        "RawData": [{"colId": 7,
+                                                     "element_id": 7,
+                                                     "measure_id": 23,
+                                                     "unit_id": 1,
+                                                     "obs_val": 6.59,
+                                                     "rowId": 325,
+                                                     "dt": "Январь 2019",
+                                                     "periodicity": "month",
+                                                     "date": "2019-02-01T00:00:00",
+                                                     "digits": 2},
+                                                    {"colId": 7,
+                                                     "element_id": 7,
+                                                     "measure_id": 23,
+                                                     "unit_id": 1,
+                                                     "obs_val": 16.6,
+                                                     "rowId": 404,
+                                                     "dt": "Август 2025",
+                                                     "periodicity": "month",
+                                                     "date": "2025-09-01T00:00:00",
+                                                     "digits": 2}
+                                                    ],
+                                        "headerData": [{"id": 7, "elname": "До 1 года, включая ''до востребования''"},
+                                                       {"id": 11, "elname": "Свыше 1 года"}],
+                                        "units": [{"id": 1, "val": "% годовых"},
+                                                  {"id": 2, "val": "%"},
+                                                  {"id": 3, "val": "млрд руб."},
+                                                  {"id": 4, "val": "млн долларов США"},
+                                                  {"id": 5, "val": "месяцев"},
+                                                  {"id": 6, "val": "млн руб."},
+                                                  {"id": 7, "val": "единиц"},
+                                                  {"id": 8, "val": "число опрошенных"},
+                                                  {"id": 9, "val": "пунктов"},
+                                                  {"id": 10, "val": "руб."}],
+                                        "DTRange": [{"FromY": 2019, "ToY": 2025}],
+                                        "SType": [
+                                            {"sType": 1,
+                                             "dsName": "Ставки по вкладам (депозитам) нефинансовых организаций в рублях",
+                                             "PublName": "В территориальном разрезе"}
+                                        ]
+                                    }
+                            )
+                        ]
+                ),
+                400: OpenApiResponse(
+                        description="Ошибка валидации входных данных.",
+                        examples=[
+                            OpenApiExample(
+                                    name="Ошибка валидации publication_id",
+                                    value={"message": "publication_id должен быть равен числу в массиве [18, 19]"}
+                            ),
+                            OpenApiExample(
+                                    name="Ошибка валидации dataset_id",
+                                    value={
+                                        "message": "dataset_id должен быть равен числу в массиве [37, 38] для publication_id=18"}
+                            ),
+                            OpenApiExample(
+                                    name="Ошибка валидации measure_id",
+                                    value={
+                                        "message": "measure_id должен быть равен числу в массиве [2, 3, 4] для publication_id=18"}
+                            ),
+                            OpenApiExample(
+                                    name="Ошибка диапазона годов",
+                                    value={"message": "from_year не может быть больше to_year"}
+                            )
+                        ]
+                ),
+                422: OpenApiResponse(
+                        description="Недоступный диапазон годов или отсутствие данных",
+                        examples=[
+                            OpenApiExample(
+                                    name="Ошибка диапазона годов",
+                                    value={"message": "Информация доступна только с 0 по 2025 год"}
+                            ),
+                            OpenApiExample(
+                                    name="Нет данных",
+                                    value={"message": "Нет данных для указанных параметров"}
+                            ),
+                            OpenApiExample(
+                                    name="Ошибка внешнего API",
+                                    value={"message": "Ошибка внешнего API: <описание ошибки>"}
+                            )
+                        ]
+                )
+            },
+            examples=[
+                OpenApiExample(
+                        name="Пример запроса для publication_id=18",
+                        value={
+                            "publication_id": 18,
+                            "dataset_id": 37,
+                            "measure_id": 2,
+                            "from_year": 2015,
+                            "to_year": 2025
+                        }
+                ),
+                OpenApiExample(
+                        name="Пример запроса для publication_id=19",
+                        value={
+                            "publication_id": 19,
+                            "dataset_id": 39,
+                            "measure_id": 23,
+                            "from_year": 2019,
+                            "to_year": 2025
+                        }
+                )
+            ]
+    )
+    def post(self, request: Request, *args, **kwargs) -> Response:
+        serializer = InterestRatesDepositSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        params = serializer.validated_data
+
+        data = InterestRatesParser.parse(
+                publication_id=params.get("publication_id"),
+                dataset_id=params.get("dataset_id"),
+                measure_id=params.get("measure_id"),
+                from_year=params.get("from_year"),
+                to_year=params.get("to_year"))
+
+        if "message" in data:
+            return Response(data, status=status.HTTP_422_UNPROCESSABLE_ENTITY)
+
+        response_serializer = InterestRatesResponseSerializer(instance=data)
         return Response(response_serializer.data, status=status.HTTP_200_OK)


### PR DESCRIPTION
In the serializers.py added InterestRatesDepositSerializer which validate and serialize request to deposits statistic. Also added BaseAPISerializer class which describe general logic of InterestRatesCreditSerializer and InterestRatesDepositSerializer

In the meta.py add CombinedMeta class of serializers.py and abstract class

In the views.py add new InterestRatesDepositAPIView which handle requests to deposit statistic

In the urls.py add path to the new InterestRatesDepositAPIView